### PR TITLE
add "whois" to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pandas
 rich
 openpyxl
 PrettyTable
- 
+whois


### PR DESCRIPTION
fix ModuleNotFoundError
root@debian:~/tig# python3 tig.py
Traceback (most recent call last):
  File "tig.py", line 12, in <module>
    import whois
ModuleNotFoundError: No module named 'whois'